### PR TITLE
Bug 1285197 - fix go get warning for taskcluster-client-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/taskcluster/taskcluster-client-go/tcclient"
+	tcclient "github.com/taskcluster/taskcluster-client-go"
 )
 
 type (

--- a/jsonschema.go
+++ b/jsonschema.go
@@ -300,20 +300,20 @@ func (jsonSubSchema *JsonSubSchema) typeDefinition(topLevel bool, extraPackages 
 		if f := jsonSubSchema.Format; f != nil {
 			if *f == "date-time" {
 				typ = "tcclient.Time"
-				extraPackages["github.com/taskcluster/taskcluster-client-go/tcclient"] = true
+				extraPackages["tcclient \"github.com/taskcluster/taskcluster-client-go\""] = true
 			}
 		}
 	}
 	switch typ {
 	case "json.RawMessage":
-		extraPackages["encoding/json"] = true
+		extraPackages["\"encoding/json\""] = true
 		if topLevel {
 			// Special case: we have here a top level RawMessage such as
 			// queue.PostArtifactRequest - therefore need to implement
 			// Marhsal and Unmarshal methods. See:
 			// http://play.golang.org/p/FKHSUmWVFD vs
 			// http://play.golang.org/p/erjM6ptIYI
-			extraPackages["errors"] = true
+			extraPackages["\"errors\""] = true
 			rawMessageTypes[jsonSubSchema.TypeName] = true
 		}
 	}
@@ -684,7 +684,7 @@ package ` + job.Package + `
 		extraPackagesContent := ""
 		for j, k := range extraPackages {
 			if k {
-				extraPackagesContent += text.Indent("\""+j+"\"\n", "\t")
+				extraPackagesContent += text.Indent(""+j+"\n", "\t")
 			}
 		}
 


### PR DESCRIPTION
This relocates `github.com/taskcluster/taskcluster-client-go/tcclient` to `github.com/taskcluster/taskcluster-client-go`.

Note, there is a TODO to remove references to `tcclient` from `jsonschema2go`, but for the moment there is still a dependency.
