### PR TITLE
Use time.Time no need for custom type

### DIFF
--- a/jsonschema.go
+++ b/jsonschema.go
@@ -300,8 +300,7 @@ func (jsonSubSchema *JsonSubSchema) typeDefinition(topLevel bool, extraPackages 
 	case "string":
 		if f := jsonSubSchema.Format; f != nil {
 			if *f == "date-time" {
-				typ = "tcclient.Time"
-				extraPackages["tcclient \"github.com/taskcluster/taskcluster-client-go\""] = true
+				typ = "time.Time"
 			}
 		}
 	}


### PR DESCRIPTION
For an example see: https://play.golang.org/p/HfDVrKgEEF

This greatly simplifies the number of special cases when working with taskcluster-client.

Okay, did I forget to add `import "time"` in the template?