### PR TITLE
Map json schema integer to go type int64

### DIFF
--- a/jsonschema.go
+++ b/jsonschema.go
@@ -292,7 +292,7 @@ func (jsonSubSchema *JsonSubSchema) typeDefinition(topLevel bool, extraPackages 
 	case "number":
 		typ = "float64"
 	case "integer":
-		typ = "int"
+		typ = "int64"
 	case "boolean":
 		typ = "bool"
 	// json type string maps to go type string, so only need to test case of when


### PR DESCRIPTION
[Spec](http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.25) says integer *matches any number with a zero fractional part* - so `int64` is safer to use than `int`, since it potentially covers a larger range of values if on a < 64 bit environment. Another option would have been [big.Int](https://golang.org/pkg/math/big/#Int) but let's hold off implementing that until we're sure we need it, and it could break a lot of existing code!